### PR TITLE
modfied api so json objects are returned

### DIFF
--- a/controller/routes/get-api-routes.js
+++ b/controller/routes/get-api-routes.js
@@ -2,15 +2,14 @@ var db = require("../../models");
 module.exports = function(app) {
 
     app.get("/", function(req, res){
-        db.Review.findAll(function (data) {
+        db.Review.findAll(function (reviewdata) {
             // console.log("View all review data");            
             var reviewObject = {
             reviewData: data
             };
 
-        // console.log("review object" + JSON.stringify(data));
-
-        return res.render("index", reviewObject);
+        //Future Direction: Working on rendering to index.handlebars template
+        // return res.render("index", reviewObject);
 
         });
     })
@@ -22,7 +21,7 @@ module.exports = function(app) {
         db.Review.findAll({}).then(function(results) {
             // console.log("Find All");
             console.log("review result" + JSON.stringify(results));
-        //   return res.json(results);
+          return res.json(results);
       
         });
     

--- a/controller/routes/html-routes.js
+++ b/controller/routes/html-routes.js
@@ -10,26 +10,12 @@ var path = require("path");
 // =============================================================
 module.exports = function(app) {
 
-  // Each of the below routes just handles the HTML page that the user gets sent to.
+  //The below route just handles the HTML page that the user gets sent to.
 
-  // index route loads view.html
+  // index route loads index.html
   app.get("/", function(req, res) {
     res.sendFile(path.join(__dirname, "./public/index.html"));
   });
 
-//   // cms route loads cms.html
-//   app.get("/cms", function(req, res) {
-//     res.sendFile(path.join(__dirname, "../public/cms.html"));
-//   });
-
-//   // blog route loads blog.html
-//   app.get("/blog", function(req, res) {
-//     res.sendFile(path.join(__dirname, "../public/blog.html"));
-//   });
-
-//   // authors route loads author-manager.html
-//   app.get("/authors", function(req, res) {
-//     res.sendFile(path.join(__dirname, "../public/author-manager.html"));
-//   });
 
 };

--- a/controller/routes/post-api-routes.js
+++ b/controller/routes/post-api-routes.js
@@ -20,6 +20,7 @@ module.exports = function(app) {
         salaryRange: field.salaryRange,
         overallExperience: parseInt(field.overallExperience),
       }).then(function(results) {
+          // return res.json(results);
           return res;
       });
     


### PR DESCRIPTION
modfied get and post api routes so json objects are returned. 

because if we "res" twice it'll always throw an error, so res.json(results) is commented out in both files  

However I tested them both and everything posts as json objects when we uncomment the code and type that url in the browser